### PR TITLE
disable build timestamps

### DIFF
--- a/configs/default_defconfig
+++ b/configs/default_defconfig
@@ -76,6 +76,8 @@ ifeq (y,$(findstring y,$(CONFIG_ICNSS) $(CONFIG_ICNSS_MODULE)))
 	endif
 endif
 
+WLAN_DISABLE_BUILD_TAG := y
+CONFIG_BUILD_TAG := n
 ifneq ($(DEVELOPER_DISABLE_BUILD_TIMESTAMP), y)
 ifneq ($(WLAN_DISABLE_BUILD_TAG), y)
 CONFIG_BUILD_TAG := y


### PR DESCRIPTION
this is already how google disables the timestamp for other devices. No idea why this was missed on redbull

Signed-off-by: anupritaisno1 <www.anuprita804@gmail.com>